### PR TITLE
chore: update link to NSA Kubernetes Hardening Guide

### DIFF
--- a/docs/built-in-rules/prevent-service-account-token-auto-mount/index.mdx
+++ b/docs/built-in-rules/prevent-service-account-token-auto-mount/index.mdx
@@ -65,4 +65,4 @@ spec:
 
 ## Read more
 
-- [Kubernetes Hardening Guidance](https://media.defense.gov/2021/Aug/03/2002820425/-1/-1/1/CTR_KUBERNETES%20HARDENING%20GUIDANCE.PDF)
+- [Kubernetes Hardening Guidance](https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF)


### PR DESCRIPTION
I noticed the link in the docs to the NSA k8s hardening guide was pointing to a previous version, which has since been removed and is now a 404.

This PR updates the link to point to the latest version of the guide.